### PR TITLE
streamline devmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ You can use this container to develop and test new version of GenPipes.
 Fist, clone genpipe somewhere under your $HOME folder three.
 
 ```
-git clone https://bitbucket.org/mugqic/genpipes $HOME/some/dir/genpipes
+git clone https://bitbucket.org/mugqic/genpipes $WORKDIR/genpipes
 ```
-Add the followin line to your .bashrc
+Add that path with the `-d` option
 
 ```
-export GENPIPES_DEV_DIR=$HOME/some/dir/genpipes
+singularity run docker://c3genomics/genpipes:$TAG -d $HOME/some/dir/genpipes
+
 ```
 
 Start the container with the normal procedure seen above. In the running container, execute the followin command:

--- a/genpiperc
+++ b/genpiperc
@@ -1,10 +1,15 @@
 #source /etc/bashrc
 #source ~/.bashrc
-if [ -z "${QUIET}" ]; then
+if [ -z "${QUIET+x}" ]; then
 echo -e "\nWait while Genpipes module are loaded. This could take a while,"
 echo -e   "  especially if the cvmfs cache is new\n"
 fi
 module use $MUGQIC_INSTALL_HOME/modulefiles
 module load mugqic/python/2.7.14
-module load mugqic/genpipes${PIPELINE_VERSION}
 
+if [ -z "${GENPIPES_DEV_DIR+x}" ]; then
+    module load mugqic/genpipes${PIPELINE_VERSION}
+else
+    module use /usr/local/Modules/modulefiles
+    module load dev_genpipes
+fi


### PR DESCRIPTION
Load  dev_genpipes version by default when the `GENPIPES_DEV_DIR` env var is set to something, or when using the `-d  $GENPIPES_DEV_DIR` option